### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ http://anijs.github.io/#using
 Work well in iPad, iPhone, Android and the [modern browsers](http://browsehappy.com/). **;)**
 
 
-## Documentation
+## Documentation [![Inline docs](http://inch-ci.org/github/anijs/anijs.svg?branch=master)](http://inch-ci.org/github/anijs/anijs)
 
 Documentation Topics can be founded in the [Wiki Pages](https://github.com/anijs/anijs/wiki).
 


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/anijs/anijs.svg)](http://inch-ci.org/github/anijs/anijs)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs (early adopters include [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

The idea is to motivate aspiring Node developers to dive into Open Source projects and read the code.
It's about *engagement*, because, while testing and code coverage are important, inline-docs are the humanly engaging factor in Open Source. This project is about making people less adverse to jumping into the code and see whats happening, because they are not left alone while doing so. I know that, because I put off reading other people's code way too long in my life.

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/anijs/anijs

What do you think?